### PR TITLE
Set video qualitity as an empty string so it wont crash when the user…

### DIFF
--- a/assets/js/app.js
+++ b/assets/js/app.js
@@ -55,7 +55,7 @@ function loadDefaults() {
     autoRetry: false,
     downloadStart: false,
     downloadEnd: false,
-    videoQuality: false,
+    videoQuality: '',
     path: false,
     defaultSubtitle: "",
     seqZeroLeft: false,


### PR DESCRIPTION
## Summary of the Pull Request

**What is this about:**

This PR fixed the problem of the users to stuck in "building course data".
You may not able to reproduce the bug because by default `videoQuality` was set to `false`, and this value is overwritten when you click the **save button** in the settings.
Because the settings persists, you wont get this error unless you **_reset your electron settings_** (I did it by doing `settings.clearAll()` )


**What is included in the PR:** 
Setting `videoQuality` to an empty string.
Doing so the validation switch wont fail in the `getLecture` function when trying to call `toLowerCase` from a boolean (the default value of `videoQuality`.

**How does someone test / validate:** 
Make sure you reset/clean the electron settings, then just try to download a course.
The course should start to download sucessfully.

## Quality ChecklistV

- [ ] **Linked issue:** #49 
