### PR TITLE
Fix lecture.quality.slice is not a function

### DIFF
--- a/app/app.js
+++ b/app/app.js
@@ -715,7 +715,13 @@ async function fetchCourseContent(courseId, courseName, courseUrl) {
 								lecture.quality = streams.minQuality;
 								break;
 							default:
-								lecture.quality = utils.isNumber(lecture.quality) ? lecture.quality : lecture.quality.slice(0, -1);
+								if (utils.isNumber(lecture.quality)) {
+									lecture.quality = lecture.quality; // Keep the number as is
+								} else if (typeof lecture.quality === "string") {
+									lecture.quality = lecture.quality.slice(0, -1); // Safely slice string
+								} else {
+									lecture.quality = null; // Or any default fallback value
+								}
 						}
 
 						if (!streams.sources[lecture.quality]) {


### PR DESCRIPTION
## Summary of the Pull Request
Thanks for contributing!

Please be sure you are following the guidelines at 
https://github.com/heliomarpm/udemy-downloader-gui/blob/master/docs/CONTRIBUTING.md

**What is this about:**
I encountered an issue while trying to download a course. The error message states: lecture.quality.slice is not a function.![image](https://github.com/user-attachments/assets/9fe999ea-1f3e-460e-8320-d8e11067ef13)

**What is included in the PR:** 
1.Check for utils.isNumber:
- If lecture.quality is a number, keep it unchanged.

2.Check if lecture.quality is a String:
- Use typeof lecture.quality === "string" to ensure that slice() is only called on strings.

3.Handle Non-String and Non-Numeric Values:
- Add a fallback or logging for invalid types.

4.Fallback Value:
- If lecture.quality is neither a valid number nor a string, you can assign a default value (e.g., null, "auto", etc.) or handle the error as needed.

**How does someone test / validate:** 

## Quality ChecklistV

- [ ] **Linked issue:** #xxx
- [ ] **Tests:** Added/updated and all pass
- [ ] **Localization:** All end user facing strings can be localized
- [ ] **Docs:** Added/ updated
<!-- - [ ] **Communication:** I've discussed this with core contributors in the issue.  -->
<!-- - [ ] **Installer:** Added/updated and all pass -->
